### PR TITLE
Allow Canvas.show to accept a DOM element or id

### DIFF
--- a/lib/canvas.js
+++ b/lib/canvas.js
@@ -45,7 +45,7 @@ function Bitmap() {
 	}
 
 	this.show = function(cvsid, rot) {
-		var cvs = document.getElementById(cvsid);
+		var cvs = cvsid instanceof window.HTMLCanvasElement ? cvsid : document.getElementById(cvsid);
 		if (pts.length == 0) {
 			cvs.width  = 32;
 			cvs.height = 32;


### PR DESCRIPTION
_Not sure whether you are accepting PR's, but if you're open to it, here is one I find useful._

---
Sometimes it is nice to render in a detached element before appending to the dom. 
`document.getElementById` will not find detached elements, so allow `Bitmap.show` to take either an id or an element.

with this change, you can write something like this
``` javascript
var canvas = document.createElement('canvas'), // element in memory, not dom
    bw = new BWIPJS();

bw.bitmap(new Bitmap());

bw.push(text);
bw.push({});

bw.call(FORMAT_MAP[tag.barcode.format], function (e) {
  if (!e) {
    bw.bitmap().show(canvas, "N");
    // now attach the element to the dom
    document.getElementsByTagName("body")[0].appendChild(canvas);
  }
});
```
