### PR TITLE
Hide console logs by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ the end of this document.
 
 ## Status 
 
-* Current bwip-js version is 0.14.0 (07-Sep-2015)
+* Current bwip-js version is 0.14.1 (18-Sep-2015)
 * Current BWIPP version is 2015-08-10
 * Node.js compatibility >= v0.10 (reported to work with v0.8 but not tested).
 * npm dependencies: none

--- a/bwip.js
+++ b/bwip.js
@@ -5,6 +5,10 @@
 // See the LICENSE file in the bwip-js root directory
 // for the extended copyright notice.
 
+var CONFIG = {
+	verbose: false
+};
+
 // The one and only global - our class constructor
 var BWIPJS = function() {
 	
@@ -39,7 +43,7 @@ var BWIPJS = function() {
 		// errorname is the name of the function
 		// Don't use an Error object - keeps the message cleaner
 		throw '[' + $error.errorname.toString() + ']\r\n\r\n' +
-			  $error.errorinfo.toString();
+				$error.errorinfo.toString();
 	}
 
 }
@@ -105,7 +109,9 @@ BWIPJS.logapi = function(fn, args) {
 		s += (i ? ', ' : '') + JSON.stringify(args[i]);
 	}
 	s += ')';
-	console.log(s);
+	if(CONFIG.verbose){
+		console.log(s);
+	}
 };
 //BWIPJS.load  = function(s) {};	// force a run-time error	
 
@@ -333,7 +339,9 @@ BWIPJS.prototype.bitmap = function(bmap) {
 }
 // operators print, =, and == are all tied to this
 BWIPJS.prototype.print = function(s) {
-	console.log(''+s);
+	if(CONFIG.verbose){
+		console.log(''+s);
+	}
 };
 
 // Converts a javascript value into a postscript value
@@ -812,8 +820,10 @@ BWIPJS.prototype.gclone = function(o) {
 // it better connects one line with the next.
 BWIPJS.prototype.drawline = function(optmz, x1, y1, x2, y2, penx, peny, merge) {
 	BWIPJS.logapi('drawline', arguments);
-	console.log('x1,y1,x2,y2=' + x1 + ',' + y1 + ',' + x2 + ',' + y2);
-	console.log('optmz,penx,peny=' + optmz + ',' + penx + ',' + peny);
+	if(CONFIG.verbose){
+		console.log('x1,y1,x2,y2=' + x1 + ',' + y1 + ',' + x2 + ',' + y2);
+		console.log('optmz,penx,peny=' + optmz + ',' + penx + ',' + peny);
+	}
 	if (optmz && (x1 == x2 || y1 == y2)) {
 		var lx = Math.round(penx);
 		var ly = Math.round(peny);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bwip-js",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Barcode generator supporting over 90 types and standards.",
   "main": "node-bwipjs",
   "scripts": {


### PR DESCRIPTION
Firstly, thanks for this repo !!

I hided the console logs behind a variable set to `false` by default because I just used this module in a production project and I can't have so much logs generated on the production server.

I haven't done an interface to change the config from outside the module, but you could do it later if you want.

Oh and please `npm publish` if you accept this pull request ! :)