### PR TITLE
bwip-js demo: Support padding around barcode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ specific options are:
     * `"I"` : Inverted 180 degree rotation.
 
 - `monochrome` : Sets the human-readable text to render in monochrome.  Boolean `true` or `false`.  Default is `false` which renders 256-level gray-scale anti-aliased text.
+- `paddingwidth` :  Sets the horizontal padding (in pixels) around the rendered barcode.
+- `paddingheight` : Sets the vertical padding (in pixels) around the rendered barcode.
 
 You will need to consult the
 [BWIPP documentation](https://github.com/bwipp/postscriptbarcode/wiki)

--- a/demo.html
+++ b/demo.html
@@ -186,6 +186,7 @@ function render() {
 	} else {
 		bw.bitmap(new Bitmap);
 	}
+	bw.bitmap().pad(+opts.paddingwidth || 0, +opts.paddingheight || 0);
 	
 	var scaleX = +document.getElementById('scaleX').value || 2;
 	var scaleY = +document.getElementById('scaleY').value || 2;

--- a/lib/canvas.js
+++ b/lib/canvas.js
@@ -38,6 +38,13 @@ function Bitmap(bgcolor) {
 	var miny = 0;	// min-y
 	var maxx = 0;	// max-x
 	var maxy = 0;	// max-y
+	var padx = 0;	// padding-x
+	var pady = 0;	// padding-y
+
+	this.pad = function(x, y) {
+		padx = x;
+		pady = y;
+	}
 
 	this.color = function(r, g, b) {
 		clr = [r, g, b];
@@ -72,8 +79,8 @@ function Bitmap(bgcolor) {
 			var h = maxy-miny+1;
 		}
 
-		cvs.width  = w;
-		cvs.height = h;
+		cvs.width  = w + (2*padx);
+		cvs.height = h + (2*pady);
 
 		var ctx = cvs.getContext('2d');
 		ctx.fillStyle = bgcolor || '#fff';
@@ -113,7 +120,7 @@ function Bitmap(bgcolor) {
 			dat[idx+2] = (dat[idx+2] * (1 - a) + c[2] * a)|0;
 			dat[idx+3] = 255;
 		}
-		ctx.putImageData(id, 0, 0);
+		ctx.putImageData(id, padx, pady);
 		cvs.style.visibility = 'visible';
 	}
 }


### PR DESCRIPTION
Include two new demo-only options for controlling horizontal/vertical
padding around the barcode: paddingwidth=N and paddingheight=M,
respectively.