### PR TITLE
Give node-bwipjs and node-zlibPNG a .js file extension.

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ bwip-js.
 ![bwip-js ISBN](http://metafloor.github.io/bwip-js/images/bwip-js-isbn-bg.png?raw=true)
 
 If you want to use BWIPP's original background color handling, look for the
-following lines in `node-bwipjs` (or `lib/canvas.js` if using the browser code):
+following lines in `node-bwip.js` (or `lib/canvas.js` if using the browser code):
 
 ```
 // Feature or bug, BWIPP does not extend the background color into
@@ -287,8 +287,8 @@ The software is organized in the following directory structure:
 		demo.html		# The bwip-js demo
 		freetype.js		# The Emscripten-compiled FreeType library
 		freetype.js.mem	# Demand loaded memory image
-		node-bwipjs		# Node.js module
-		node-zlibPNG	# Node.js module that implements a PNG encoder
+		node-bwip.js	# Node.js module
+		node-zlibPNG.js	# Node.js module that implements a PNG encoder
 		package.json	# Node.js/npm configuration
 		bwipp/			# The cross-compiled BWIPP encoders and renderers
 		lib/			# Utilities required by the demo
@@ -312,7 +312,7 @@ To run the demo from your HTTP server, you should install the bwip-js directory
 under the server's root document directory and modify the server's configuration
 files, if necessary.  Then navigate your browser to the `bwip-js/demo.html` file.
 
-If you would like to implement your own interface to bwip-js, see [Integrating bwip.js Into Your Code](https://github.com/metafloor/bwip-js/wiki/Integrating-bwip.js-Into-Your-Code).  I would also recommend looking at the `node-bwipjs` module to see how it
+If you would like to implement your own interface to bwip-js, see [Integrating bwip.js Into Your Code](https://github.com/metafloor/bwip-js/wiki/Integrating-bwip.js-Into-Your-Code).  I would also recommend looking at the `node-bwip.js` module to see how it
 was done for Node.js.  Getting the FreeType module to cooperate with the
 BWIPP cross-compiled code was not straightforward.
 

--- a/node-bwip.js
+++ b/node-bwip.js
@@ -5,11 +5,10 @@
 // See the LICENSE file in the bwip-js root directory
 // for the extended copyright notice.
 //
-var url	= require('url'),
-	fs	= require('fs'),
-	vm	= require('vm'),
-	zlibPNG	= require(__dirname + '/node-zlibPNG')
-	;
+var url = require('url');
+var fs = require('fs');
+var vm = require('vm');
+var zlibPNG = require('./node-zlibPNG');
 
 // The global inside a sandboxed context is virtually useless.  None of
 // the goodies available in a primary context.

--- a/node-bwip.js
+++ b/node-bwip.js
@@ -1,4 +1,4 @@
-// file: node-bwipjs
+// file: node-bwip.js
 //
 // Copyright (c) 2011-2015 Mark Warren
 //

--- a/node-zlibPNG.js
+++ b/node-zlibPNG.js
@@ -1,4 +1,4 @@
-// file: node-zlibPNG
+// file: node-zlibPNG.js
 //
 // Implements a PNG encoder using only the built-in zlib module.
 // No other dependencies.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bwip-js",
   "version": "0.15.1",
   "description": "Barcode generator supporting over 90 types and standards.",
-  "main": "node-bwipjs",
+  "main": "node-bwip.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
JavaScript modules should have a file extension, preferably `.js`, unless there's a good reason to use something else (such as `.jsx`, assuming you have an appropriate `require.extensions[".jsx"]` hook). Files without file extensions are confusing to editors that attempt to recognize file types, and also confusing to JavaScript bundling tools like Meteor (see https://github.com/meteor/meteor/issues/6699).

That particular problem can be fixed on Meteor's side, but I hope you'll consider taking this pull request, unless you had a good reason for omitting the file extension.