### PR TITLE
Fix run 'node server.js' from absolute path

### DIFF
--- a/server.js
+++ b/server.js
@@ -4,8 +4,12 @@
 // 
 // Usage:  node server
 //
-var http   = require('http');
-var bwipjs = require('./node-bwipjs');	// ./ required for local use
+var http     = require('http');
+var bwipjs   = require('./node-bwipjs');	// ./ required for local use
+var fs       = require('fs');
+var path     = require('path');
+var hostname = '127.0.0.1';
+var port     = 3030;
 
 // Example of how to load a font into bwipjs. 
 //  bwipjs.loadFont(fontname, sizemult, fontdata)
@@ -14,12 +18,12 @@ var bwipjs = require('./node-bwipjs');	// ./ required for local use
 //  bwipjs.unloadFont(fontname)
 //
 bwipjs.loadFont('Inconsolata', 108,
-			require('fs').readFileSync('fonts/Inconsolata.otf', 'binary'));
+			fs.readFileSync(path.resolve(__dirname, 'fonts/Inconsolata.otf'), 'binary'));
 
 http.createServer(function(req, res) {
 	// If the url does not begin /?bcid= then 404.  Otherwise, we end up
 	// returning 400 on requests like favicon.ico.
-	if (req.url.indexOf('/?bcid=') != 0) {
+	if (req.url.indexOf('/?bcid=') !== 0) {
 		res.writeHead(404, { 'Content-Type':'text/plain' });
 		res.end('BWIP-JS: Unknown request format.', 'utf8');
 	} else {
@@ -27,6 +31,6 @@ http.createServer(function(req, res) {
 		bwipjs(req, res, { sizelimit:1024*1024 });
 	}
 
-}).listen(3030);
-
-console.log('listening on 3030');
+}).listen(port, hostname, function() {
+	console.log('BWIP-JS listening on http://%s:%s/', hostname, port);
+});


### PR DESCRIPTION
Allow to run the HTTP server from absolute path
`$ node /usr/local/lib/node_modules/bwip-js/server.js`

This is really useful to run HTTP server using pm2
`$ pm2 start /usr/local/lib/node_modules/bwip-js/server.js`

**before**
```
$ node /usr/local/lib/node_modules/bwip-js/server.js 
fs.js:549
  return binding.open(pathModule._makeLong(path), stringToFlags(flags), mode);
                 ^

Error: ENOENT: no such file or directory, open 'fonts/Inconsolata.otf'
    at Error (native)
    at Object.fs.openSync (fs.js:549:18)
    at Object.fs.readFileSync (fs.js:397:15)
    at Object.<anonymous> (/usr/local/lib/node_modules/bwip-js/server.js:17:18)
    at Module._compile (module.js:410:26)
    at Object.Module._extensions..js (module.js:417:10)
    at Module.load (module.js:344:32)
    at Function.Module._load (module.js:301:12)
    at Function.Module.runMain (module.js:442:10)
    at startup (node.js:136:18)
```
**after**
```
$ node /usr/local/lib/node_modules/bwip-js/server.js 
BWIP-JS listening on http://127.0.0.1:3030/
```