### PR TITLE
Removed use of `__dirname` in `require()` calls

### DIFF
--- a/node-bwipjs.js
+++ b/node-bwipjs.js
@@ -8,10 +8,10 @@
 "use strict";
 
 var url	= require('url'),
-	bwipp = require(__dirname + '/bwipp'),
-	bwipjs = require(__dirname + '/bwipjs'),
-	Bitmap = require(__dirname + '/node-bitmap'),
-	fixedfont = require(__dirname + '/node-fonts')	// freetype alternative, default
+	bwipp = require('./bwipp'),
+	bwipjs = require('./bwipjs'),
+	Bitmap = require('./node-bitmap'),
+	fixedfont = require('./node-fonts')	// freetype alternative, default
 	;
 
 // freetype is the module, freefont is the font manager interface identical to fixedfont
@@ -150,8 +150,8 @@ module.exports.toBuffer = function(args, callback) {
 
 module.exports.useFreetype = function(useFT) {
 	if (useFT || useFT === undefined) {
-		freetype = require(__dirname + '/freetype');
-		
+		freetype = require('./freetype');
+
 		var ft_monochr	= freetype.cwrap("monochrome", 'number', ['number']);
 		var ft_lookup	= freetype.cwrap("find_font", 'number', ['string']);
 		var ft_bitmap	= freetype.cwrap("get_bitmap", 'number',


### PR DESCRIPTION
I was trying to use [`pkg`](https://npm.im/pkg) on a binary that used this module. It was unable to run because of the "dynamic" require that was being done.