### PR TITLE
Don't advertise the browser entry-point as ES6 module

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "1.7.1",
   "description": "JavaScript barcode generator supporting over 90 types and standards.",
   "main": "node-bwipjs.js",
-  "module": "browser-bwipjs.js",
   "browser": "browser-bwipjs.js",
   "bin": {
     "bwip-js": "./bin/node-bwipjs.js"


### PR DESCRIPTION
When bundling the lib with Webpack and running it under NodeJS (with webpack target 'node'), you should get `node-bwipjs.js` when calling `require('bwip-js')`, no?

But actually the file `browser-bwipjs.js` is required, as specified by the `module` property in `package.json`.

See: https://github.com/webpack/webpack/issues/5756

The fix is easy... ;)