### PR TITLE
bwipjs_fonts.loadfonts: allow concurrent calls with different callbacks

### DIFF
--- a/lib/xhr-fonts.js
+++ b/lib/xhr-fonts.js
@@ -54,8 +54,15 @@ bwipjs_fonts.monochrome = function monochrome(mono) {
 	this.monocolor = mono;
 };
 
+var callbacks = []
+var count = 0;
+function flushCallbacks() {
+	callbacks.forEach(function(cb) { cb() });
+	callbacks = []
+	console.log("callback flushed")
+}
 bwipjs_fonts.loadfonts = function loadfonts(callback) {
-	var count = 0;
+	callbacks.push(callback);
 	for (var temp in this.toload) {
 		(function(fontpath, font) {
 			var xhr = new XMLHttpRequest;
@@ -67,7 +74,7 @@ bwipjs_fonts.loadfonts = function loadfonts(callback) {
 					font.view  = new DataView(xhr.response);
 				}
 				if (--count == 0) {
-					callback();
+					flushCallbacks();
 				}
 			}
 
@@ -78,7 +85,7 @@ bwipjs_fonts.loadfonts = function loadfonts(callback) {
 	this.toload = {};
 
 	if (!count) {
-		callback();
+		flushCallbacks();
 	}
 };
 


### PR DESCRIPTION
Here is a patch allowing multiple calls to bwipjs_fonts.loadfonts with different callbacks.

Previously, in such of code, it triggers the second callback too early thus the font is not loaded which cause some troubles :)

```
bwipjs_fonts.loadfonts(function() {
  console.log("a")
})
bwipjs_fonts.loadfonts(function() {
  console.log("b")
})
```