### PR TITLE
Replace deprecated new Buffer() with Buffer.from()

### DIFF
--- a/node-bitmap.js
+++ b/node-bitmap.js
@@ -126,7 +126,7 @@ module.exports = function(rot, bgcolor, opts) {
 		if (ncolors <= 256) {
 			// Palette Color
 			_imgrow  = _imgw + 2*_padx + 1;
-			_imgbuf  = new Buffer(_imgrow * (_imgh + 2*_pady));
+			_imgbuf  = Buffer.from(_imgrow * (_imgh + 2*_pady));
 			_pngtype = PNGTYPE_PALETTE;
 
 			_palette = [ bgcolor ];
@@ -137,7 +137,7 @@ module.exports = function(rot, bgcolor, opts) {
 		} else {
 			// TrueColor with Alpha
 			_imgrow  = (_imgw + 2*_padx) * 4 + 1;
-			_imgbuf  = new Buffer(_imgrow * (_imgh + 2*_pady));
+			_imgbuf  = Buffer.from(_imgrow * (_imgh + 2*_pady));
 			_pngtype = PNGTYPE_TRUEALPHA;
 
 			this.set = setTrueAlpha
@@ -324,7 +324,7 @@ module.exports = function(rot, bgcolor, opts) {
 			}
 
 			// Emulate a byte-stream
-			var png = new Buffer(length);
+			var png = Buffer.from(length);
 			var pngoff = 0;	// running offset into the png buffer
 
 			write('\x89PNG\x0d\x0a\x1a\x0a'); // PNG file header


### PR DESCRIPTION
I know a change similar to this was reverted 2 years ago, but perhaps now is the right time to either merge this or fork for support for versions of node that are more recent (i.e. newer that a few years).