### PR TITLE
cleanup SVG syntax & harmonize `color` regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ The return value from `toSVG()` is a string containing a fully qualified SVG def
 including a `viewBox` attribute that defines the natural width and height of the image, in pixels.
 
 ```
-<svg version="1.1" viewBox="0 0 242 200" xmlns="http://www.w3.org/2000/svg">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 242 200">
    ...
 </svg>
 ```

--- a/README.md
+++ b/README.md
@@ -393,7 +393,7 @@ span.style.display = 'inline-block';
 span.style.width = width + 'px';
 span.style.height = height + 'px';
 span.innerHTML = svg;
-document.body.addChild(span);
+document.body.appendChild(span);
 ```
 
 The `toSVG()` method links to all BWIPP encoders, so it cannot be used with

--- a/examples/drawing-example.js
+++ b/examples/drawing-example.js
@@ -99,7 +99,7 @@ function DrawingExample(opts, canvas) {
             ctx.setTransform(1, 0, 0, 1, 0, 0);    // Reset to unity transform
 
             // Set background before the transform makes this tricky.
-            if (/^[0-9a-fA-F]{6}$/.test(''+opts.backgroundcolor)) {
+            if (/^[0-9A-Fa-f]{6}$/.test(''+opts.backgroundcolor)) {
                 ctx.fillStyle = '#' + opts.backgroundcolor;
                 ctx.fillRect(0, 0, canvas.width, canvas.height);
             } else {

--- a/examples/drawing-pdfkit.js
+++ b/examples/drawing-pdfkit.js
@@ -105,7 +105,7 @@ function DrawingPDFKit(doc, opts, FontLib) {
             doc.save();
             doc.lineCap('butt');
 
-            if (/^[0-9a-fA-F]{6}$/.test(''+opts.backgroundcolor)) {
+            if (/^[0-9A-Fa-f]{6}$/.test(''+opts.backgroundcolor)) {
                 gs_dx = gs_dy = 0;
                 moveTo(0, 0);
                 lineTo(width, 0);

--- a/src/bwipjs.js
+++ b/src/bwipjs.js
@@ -146,7 +146,7 @@ BWIPJS.prototype.setcolor = function(s) {
     if (!s) {
         return;
     }
-    if (!/^(?:#?[0-9a-fA-F]{3}(?:[0-9a-fA-F]{3})?|[0-9a-fA-F]{8})$/.test(s)) {
+    if (!/^(?:#?[0-9A-Fa-f]{3}(?:[0-9A-Fa-f]{3})?|[0-9A-Fa-f]{8})$/.test(s)) {
         throw new Error('bwip-js: invalid color: ' + s); 
     }
     if (s[0] == '#') {

--- a/src/bwipp.js
+++ b/src/bwipp.js
@@ -181,7 +181,7 @@ function $cvrs(s, n, r) {
 // This is only used by BWIPP to convert <XX> string literals.
 function $cvx(s) {
     s = $z(s)
-    var m = /^\s*<((?:[0-9a-fA-F]{2})+)>\s*$/.exec(s);
+    var m = /^\s*<((?:[0-9A-Fa-f]{2})+)>\s*$/.exec(s);
     if (!m) {
         throw new Error('cvx: not a <HH> hex string literal');
     }

--- a/src/drawing-canvas.js
+++ b/src/drawing-canvas.js
@@ -33,7 +33,7 @@ function DrawingCanvas(canvas, maybe) {
 
 		// Set background 
 		ctx.setTransform(1, 0, 0, 1, 0, 0);
-		if (/^[0-9a-fA-F]{6}$/.test(''+opts.backgroundcolor)) {
+		if (/^[0-9A-Fa-f]{6}$/.test(''+opts.backgroundcolor)) {
 			ctx.fillStyle = '#' + opts.backgroundcolor;
 			ctx.fillRect(0, 0, width, height);
 		} else {

--- a/src/drawing-svg.js
+++ b/src/drawing-svg.js
@@ -266,9 +266,8 @@ function DrawingSVG() {
                 linesvg += lines[key] + '" />\n';
             }
             var bg = opts.backgroundcolor;
-            //return '<svg version="1.1" width="' + gs_width + '" height="' + gs_height +
-            return '<svg version="1.1" viewBox="0 0 ' + gs_width + ' ' + gs_height +
-                        '" xmlns="http://www.w3.org/2000/svg">\n' +
+
+            return '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ' + gs_width + ' ' + gs_height + '">\n' +
 						(clips.length ? '<defs>' + clips.join('') + '</defs>' : '') +
                         (/^[0-9A-Fa-f]{6}$/.test(''+bg)
                             ? '<rect width="100%" height="100%" fill="#' + bg + '" />\n'

--- a/src/drawing-zlibpng.js
+++ b/src/drawing-zlibpng.js
@@ -55,7 +55,7 @@ function DrawingZlibPng(callback, maybe) {
 		image_height = height;
 
 		// Set background 
-		if (/^[0-9a-fA-F]{6}$/.test(''+opts.backgroundcolor)) {
+		if (/^[0-9A-Fa-f]{6}$/.test(''+opts.backgroundcolor)) {
 			var rgb = opts.backgroundcolor;
 			fillRGB(parseInt(rgb.substr(0,2), 16),
 					parseInt(rgb.substr(2,2), 16),

--- a/src/exports.js
+++ b/src/exports.js
@@ -257,7 +257,7 @@ function DrawingDataURL(opts, callback) {
 // Returns a string containing a fully qualified SVG definition,
 // including the natural width and height of the image, in pixels:
 //
-//  <svg version="1.1" width="242" height="200" xmlns="http://www.w3.org/2000/svg">
+//  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 242 200">
 //   ...
 //  </svg>
 //

--- a/src/exports.js
+++ b/src/exports.js
@@ -281,7 +281,7 @@ function FixupOptions(opts) {
 	// the drawing interface is consistent.  Likewise, if in CSS-style #rgb or #rrggbb.
     if (opts.backgroundcolor) {
         var bgc = ''+opts.backgroundcolor;
-        if (/^[0-9a-fA-F]{8}$/.test(bgc)) {
+        if (/^[0-9A-Fa-f]{8}$/.test(bgc)) {
             var c = parseInt(bgc.substr(0,2), 16) / 255;
             var m = parseInt(bgc.substr(2,2), 16) / 255;
             var y = parseInt(bgc.substr(4,2), 16) / 255;
@@ -296,9 +296,9 @@ function FixupOptions(opts) {
             if (bgc[0] == '#') {
                 bgc = bgc.substr(1);
             }
-            if (/^[0-9a-fA-F]{6}$/.test(bgc)) {
+            if (/^[0-9A-Fa-f]{6}$/.test(bgc)) {
                 opts.backgroundcolor = bgc;
-            } else if (/^[0-9a-fA-F]{3}$/.test(bgc)) {
+            } else if (/^[0-9A-Fa-f]{3}$/.test(bgc)) {
                 opts.backgroundcolor = bgc[0] + bgc[0] + bgc[1] + bgc[1] + bgc[2] + bgc[2];
             } else {
                 throw new Error('bwip-js: invalid backgroundcolor: ' + opts.backgroundcolor);


### PR DESCRIPTION
changes as requested  ; ref. https://github.com/metafloor/bwip-js/pull/324
harmonize `HEX` regex ; regarding ASCII order of chars `0-9 A-F a-f`